### PR TITLE
Add user-agent header to wget parameters to fix download errors

### DIFF
--- a/updater/mcserver_autoupdater.py
+++ b/updater/mcserver_autoupdater.py
@@ -53,7 +53,7 @@ logfile = minecraft_directory+'/updater/update.log'
 running_files = os.listdir(minecraft_directory+'/running')
 if len(running_files) == 0:
     # Download server binary
-    subprocess.run(['wget', '-P', minecraft_directory+'/updater', '-c', download_link])
+    subprocess.run(['wget', '--user-agent', HEADERS['User-Agent'], '-P', minecraft_directory+'/updater', '-c', download_link])
     # Save the download link to a text file
     with open(download_link_file, 'w') as file:
         file.write(download_link)
@@ -70,7 +70,7 @@ if len(running_files) == 0:
 
 elif download_link != prev_download_link:
     # Download server binary
-    subprocess.run(['wget', '-P', minecraft_directory+'/updater', '-c', download_link])
+    subprocess.run(['wget', '--user-agent', HEADERS['User-Agent'], '-P', minecraft_directory+'/updater', '-c', download_link])
     # Save the download link to a text file
     with open(download_link_file, 'w') as file:
         file.write(download_link)


### PR DESCRIPTION
The servers are now requiring a valid user agent in the post request to download the bedrock server.  This change sets the user agent string in the wget parameters.

Fixes #3